### PR TITLE
Add files via upload

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const xml = require('xml2js');
 const colors = require('colors');
-const Table = require('cli-table2');
+const Table = require('cli-table3');
 
 const parser = new xml.Parser();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quran",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "The Holy Quran for the commandline.",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
   "author": "Sarfraz Ahmed <sarfraznawaz2005@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "cli-table2": "^0.2.0",
+    "cli-table3": "^0.6",
     "commander": "^2.14.1",
     "xml2js": "^0.4.19"
   },


### PR DESCRIPTION
npm lists various security vulnerabilities from specific outdated versions of lodash when installing. cli-table2 relies upon these versions. cli-table2 is a stale project maintained now as cli-table3. 